### PR TITLE
Ignore AI assistant folders in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ farmdata2_modules/**/cypress/videos/*
 **/__pycache__
 
 .DS_Store
+
+# AI assistants / local AI tooling
+.chatgpt/
+.claude/
+.gemini/
+.ai/
+ai/
+ai-tools/


### PR DESCRIPTION
Update the .gitignore file to exclude directories associated with local AI tools and assistants (for example, ChatGPT, Gemini, Claude, and other AI-generated artifacts).

These directories may contain generated content, prompts, logs, or local configuration files that should not be committed to the repository. Excluding them helps keep the codebase clean and prevents accidental inclusion of non-source or experimental files.

ref #44 